### PR TITLE
Add GitHub Actions workflow skeleton for drellabot automation

### DIFF
--- a/.github/workflows/agentic-build.yml
+++ b/.github/workflows/agentic-build.yml
@@ -1,0 +1,90 @@
+name: "Agentic Build"
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    # Only run on PRs created by the drellabot workflows (issue/* or impl/* branches)
+    if: startsWith(github.head_ref, 'issue/') || startsWith(github.head_ref, 'impl/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Locate spec file
+        id: spec
+        run: |
+          set -euo pipefail
+
+          # For issue/* branches the spec lives in done/
+          # For impl/* branches it was moved from in-progress/ to done/
+          spec_file=$(git diff --name-only --diff-filter=A origin/main...HEAD \
+            -- 'done/*.md' | head -n 1 || true)
+
+          if [ -z "$spec_file" ]; then
+            echo "No spec file found in the PR diff."
+            exit 1
+          fi
+
+          echo "file=$spec_file" >> "$GITHUB_OUTPUT"
+          echo "Spec file: $spec_file"
+
+      - name: Run agentic workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRELLABOT_TOKEN: ${{ secrets.DRELLABOT_TOKEN }}
+          SPEC_FILE: ${{ steps.spec.outputs.file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          spec_content=$(cat "$SPEC_FILE")
+
+          # TODO: Replace this stub with the actual agentic dispatch.
+          # This is where you call your agent (Codex, Cursor, custom LLM
+          # pipeline, etc.) and pass the spec content for implementation.
+          #
+          # Example placeholder:
+          #   curl -s -X POST "$DRELLABOT_API/build" \
+          #     -H "Authorization: Bearer $DRELLABOT_TOKEN" \
+          #     -d "{\"spec\": \"$spec_content\", \"pr\": $PR_NUMBER}"
+          #
+          # The agent would then push implementation commits to this branch.
+
+          echo "Agentic workflow stub — spec content:"
+          echo "$spec_content"
+
+      - name: Commit implementation artifacts
+        run: |
+          set -euo pipefail
+
+          git config user.name  "drellabot"
+          git config user.email "drellabot@users.noreply.github.com"
+
+          # TODO: After the agentic workflow produces files, stage and commit
+          # them here. This is a no-op until the agent is wired up.
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "impl: agentic build artifacts"
+            git push origin HEAD
+          else
+            echo "No new artifacts to commit."
+          fi
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "Agentic build complete. Ready for human review."

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,0 +1,71 @@
+name: "Issue → PR"
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  create-spec-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build spec file and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+
+          # Slugify the issue title into a filename-safe kebab-case string
+          slug=$(echo "$ISSUE_TITLE" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9]/-/g' \
+            | sed 's/--*/-/g' \
+            | sed 's/^-//;s/-$//')
+          slug="${slug:0:60}"
+
+          branch="issue/${ISSUE_NUMBER}-${slug}"
+          spec_file="done/${slug}.md"
+
+          git config user.name  "drellabot"
+          git config user.email "drellabot@users.noreply.github.com"
+          git checkout -b "$branch"
+
+          # Write the issue content as a spec file with front-matter
+          cat > "$spec_file" <<SPEC
+          ---
+          source: issue
+          issue: ${ISSUE_NUMBER}
+          url: ${ISSUE_URL}
+          author: ${ISSUE_AUTHOR}
+          ---
+
+          # ${ISSUE_TITLE}
+
+          ${ISSUE_BODY}
+          SPEC
+          # Remove leading whitespace added by the heredoc indentation
+          sed -i 's/^          //' "$spec_file"
+
+          git add "$spec_file"
+          git commit -m "spec: add issue #${ISSUE_NUMBER} – ${ISSUE_TITLE}"
+          git push origin "$branch"
+
+          gh pr create \
+            --title "spec: ${ISSUE_TITLE}" \
+            --body "Automatically created from issue #${ISSUE_NUMBER}.
+
+          Closes #${ISSUE_NUMBER}" \
+            --head "$branch" \
+            --base main

--- a/.github/workflows/spec-implementation.yml
+++ b/.github/workflows/spec-implementation.yml
@@ -1,0 +1,66 @@
+name: "Spec → Implementation PR"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "in-progress/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-impl-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect new specs and open implementation PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name  "drellabot"
+          git config user.email "drellabot@users.noreply.github.com"
+
+          # Find spec files added or modified in in-progress/ by this push
+          specs=$(git diff --name-only --diff-filter=AM HEAD~1 HEAD \
+            -- 'in-progress/*.md' || true)
+
+          if [ -z "$specs" ]; then
+            echo "No new or modified specs in in-progress/. Nothing to do."
+            exit 0
+          fi
+
+          echo "Specs to process:"
+          echo "$specs"
+
+          while IFS= read -r spec; do
+            basename=$(basename "$spec")
+            slug="${basename%.md}"
+            branch="impl/${slug}"
+            dest="done/${basename}"
+
+            # Each spec gets its own branch so PRs are independent
+            git checkout main
+            git checkout -b "$branch"
+
+            git mv "$spec" "$dest"
+            git commit -m "impl: move ${basename} to done/ for implementation"
+            git push origin "$branch"
+
+            gh pr create \
+              --title "impl: ${slug}" \
+              --body "Implementation PR for spec \`${basename}\`.
+
+          The spec has been moved from \`in-progress/\` to \`done/\`.
+          The agentic workflow will deliver the implementation on this branch." \
+              --head "$branch" \
+              --base main
+
+          done <<< "$specs"

--- a/.github/workflows/spec-review.yml
+++ b/.github/workflows/spec-review.yml
@@ -1,0 +1,77 @@
+name: "Spec Review"
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review-spec:
+    if: github.event.label.name == 'ready'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify changed specs
+        id: specs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          specs=$(gh pr diff "$PR_NUMBER" --name-only \
+            | grep '^in-progress/' \
+            | grep '\.md$' || true)
+
+          if [ -z "$specs" ]; then
+            echo "No spec files found under in-progress/ in this PR."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          # Store the file list for the next step
+          echo "$specs" > /tmp/spec_files.txt
+          echo "Specs to review:"
+          cat /tmp/spec_files.txt
+
+      - name: Review specs
+        if: steps.specs.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DRELLABOT_TOKEN: ${{ secrets.DRELLABOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r spec; do
+            echo "Reviewing: $spec"
+            content=$(cat "$spec")
+
+            # TODO: Send $content to an LLM / drellabot API for review.
+            # The API should return a verdict (approve / request_changes) and
+            # a review body with feedback on gaps or ambiguity.
+            #
+            # Example placeholder:
+            #   response=$(curl -s -X POST "$DRELLABOT_API/review" \
+            #     -H "Authorization: Bearer $DRELLABOT_TOKEN" \
+            #     -d "{\"spec\": \"$content\"}")
+            #   verdict=$(echo "$response" | jq -r '.verdict')
+            #   body=$(echo "$response" | jq -r '.body')
+
+            verdict="APPROVE"
+            body="Spec looks good. (automated stub — replace with real review)"
+          done < /tmp/spec_files.txt
+
+          if [ "$verdict" = "APPROVE" ]; then
+            gh pr review "$PR_NUMBER" --approve --body "$body"
+          else
+            gh pr review "$PR_NUMBER" --request-changes --body "$body"
+          fi


### PR DESCRIPTION
Four workflows covering both interaction tracks:
- issue-to-pr: converts new issues into spec PRs in done/
- spec-review: reviews specs when the "ready" label is added
- spec-implementation: picks up merged specs and opens implementation PRs
- agentic-build: shared agentic workflow stub for both tracks